### PR TITLE
[UPD]Api Banco inter V1 para V2

### DIFF
--- a/src/erpbrasil/bank/inter/api.py
+++ b/src/erpbrasil/bank/inter/api.py
@@ -53,7 +53,7 @@ class ApiInter(object):
         )
         if not response.text:
             print("Sem resposta do serviço de OAuth.")
-            exit(1)
+            return
         # Isola o access_token do JSON recebido
         access_token = response.json().get("access_token")
         if not access_token:

--- a/src/erpbrasil/bank/inter/api.py
+++ b/src/erpbrasil/bank/inter/api.py
@@ -52,13 +52,12 @@ class ApiInter(object):
             timeout=(10)
         )
         if not response.text:
-            print("Sem resposta do serviço de OAuth, provavelmente estourou o limite de chamadas por minuto...")
+            print("Sem resposta do serviço de OAuth.")
             exit(1)
         # Isola o access_token do JSON recebido
         access_token = response.json().get("access_token")
         if not access_token:
-            print("Não foi possível obter o access_token do JSON de resposta.")
-            exit(1)
+            return
         TOKEN = access_token
         return TOKEN
 

--- a/src/erpbrasil/bank/inter/api.py
+++ b/src/erpbrasil/bank/inter/api.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import requests
+from datetime import datetime
 
 FILTRAR_POR = [
     'TODOS',
@@ -26,16 +27,56 @@ ORDENAR_CONSULTA_POR = [
 class ApiInter(object):
     """ Implementa a Api do Inter"""
 
-    _api = 'https://apis.bancointer.com.br:8443/openbanking/v1/certificado/boletos'
+    _api = 'https://cdpj.partners.bancointer.com.br/cobranca/v2/boletos'
+    data_do_ultimo_token = None
+    token = None
 
-    def __init__(self, cert, conta_corrente):
+    def __init__(self, cert, conta_corrente, client_id, client_secret):
         self._cert = cert
         self.conta_corrente = conta_corrente
+        self._client_id = client_id
+        self._client_secret = client_secret
+
+    def _prepare_token(self):
+        URL_OAUTH = "https://cdpj.partners.bancointer.com.br/oauth/v2/token"
+        D1 = "client_id={}".format(self._client_id)
+        D2 = "client_secret={}".format(self._client_secret)
+        D3 = "scope=boleto-cobranca.read boleto-cobranca.write"
+        D4 = "grant_type=client_credentials"
+        DADOS = f"{D1}&{D2}&{D3}&{D4}"
+        response = requests.post(
+            URL_OAUTH,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data=DADOS,
+            cert=self._cert,
+            timeout=(10)
+        )
+        if not response.text:
+            print("Sem resposta do serviço de OAuth, provavelmente estourou o limite de chamadas por minuto...")
+            exit(1)
+        # Isola o access_token do JSON recebido
+        access_token = response.json().get("access_token")
+        if not access_token:
+            print("Não foi possível obter o access_token do JSON de resposta.")
+            exit(1)
+        TOKEN = access_token
+        return TOKEN
+
 
     def _prepare_headers(self):
+        if self.token is not None:
+            tempo_token = (datetime.now() - self.data_do_ultimo_token).total_seconds()
+            if tempo_token > 3600:
+                new_token = self._prepare_token()
+                self.data_do_ultimo_token = datetime.now()
+                self.token = new_token
+        else:
+            self.token = self._prepare_token()
+            self.data_do_ultimo_token = datetime.now()
         return {
-            'content-type': 'application/json',
-            'x-inter-conta-corrente': self.conta_corrente,
+            "Authorization": "Bearer " + self.token,
+            "Content-type": "application/json",
+            "x-inter-conta-corrente": self.conta_corrente,
         }
 
     def _call(self, http_request, url, params=None, data=None, **kwargs):
@@ -43,23 +84,22 @@ class ApiInter(object):
             url,
             headers=self._prepare_headers(),
             params=params or {},
-            data=json.dumps(data or {}),
+            data=data,
             cert=self._cert,
-            verify=False,
+            verify=True,
             **kwargs
         )
         if response.status_code > 299:
-            error = response.json()
             message = '%s - Código %s' % (
                 response.status_code,
-                error.get('error-code')
+                response.text,
             )
             raise Exception(message)
         return response
 
     def boleto_inclui(self, boleto):
         """ POST
-        https://apis.bancointer.com.br:8443/openbanking/v1/certificado/boletos
+        https://cdpj.partners.bancointer.com.br/cobranca/v2/boletos
 
         :param boleto:
         :return:
@@ -71,7 +111,7 @@ class ApiInter(object):
         )
         return result.content and result.json() or result.ok
 
-    def boleto_consulta(self, filtrar_por='TODOS', data_inicial=None, data_final=None,
+    def boleto_consulta(self, filtrar_data_por='VENCIMENTO', data_inicial=None, data_final=None,
                         ordenar_por='NOSSONUMERO'):
         """ GET
         https://apis.bancointer.com.br:8443/openbanking/v1/certificado/boletos?
@@ -80,7 +120,7 @@ class ApiInter(object):
             dataFinal=2020-12-01&
             ordenarPor=SEUNUMERO
 
-        :param filtrar_por:
+        :param filtrarDatapor:
         :param data_inicial:
         :param data_final:
         :param ordenar_por:
@@ -90,7 +130,7 @@ class ApiInter(object):
             requests.get,
             url=self._api,
             params=dict(
-                filtrarPor=filtrar_por,
+                filtrarDataPor=filtrar_data_por,
                 dataInicial=data_inicial,
                 dataFinal=data_final,
                 ordenarPor=ordenar_por
@@ -100,29 +140,28 @@ class ApiInter(object):
 
     def boleto_baixa(self, nosso_numero, codigo_baixa):
         """ POST
-        https://apis.bancointer.com.br:8443/openbanking/v1/certificado/boletos/
-            00576501185/baixas
+        https://cdpj.partners.bancointer.com.br/cobranca/v2/boletos/
+        {nossoNumero}/cancelar
 
         :param nosso_numero:
         :return:
         """
-        url = '{}/{}/baixas'.format(
+        url = '{}/{}/cancelar'.format(
             self._api,
             nosso_numero
         )
         result = self._call(
             requests.post,
             url=url,
-            data=dict(
-                codigoBaixa=codigo_baixa,
-            )
+            data='{{"motivoCancelamento":"{}"}}'.format(codigo_baixa)
+
         )
         return result.content and result.json() or result.ok
 
     def boleto_pdf(self, nosso_numero):
         """ GET
-        https://apis.bancointer.com.br:8443/openbanking/v1/certificado/boletos/
-            00595764723/pdf
+        https://cdpj.partners.bancointer.com.br/cobranca/v2/boletos/
+        {nossoNumero}/pdf
 
         :param nosso_numero:
         :return:

--- a/src/erpbrasil/bank/inter/boleto.py
+++ b/src/erpbrasil/bank/inter/boleto.py
@@ -86,7 +86,7 @@ class BoletoInter:
             multa=self.multa,
             mora=self.mora,
             cnpjCPFBeneficiario=self._sender.identifier,
-            numDiasAgenda="SESSENTA"
+            numDiasAgenda="60"
         )
 
         if self._instructions:

--- a/tests/boleto_inclui.yaml
+++ b/tests/boleto_inclui.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: '{"pagador": {"cpfCnpj": "26103754097", "nome": "Sacado Teste", "email":
+      "mileo@kmee.com.br", "telefone": "988763663", "cep": "31327130", "numero": "15",
+      "complemento": "", "bairro": "CENTRO", "cidade": "SAO PAULO", "uf": "SP", "endereco":
+      "Rua dos TESTES", "ddd": "35", "tipoPessoa": "FISICA"}, "dataEmissao": "2023-06-27",
+      "seuNumero": "4560", "dataLimite": "SESSENTA", "dataVencimento": "2023-07-05",
+      "desconto1": {"codigoDesconto": "NAOTEMDESCONTO", "taxa": 0, "valor": 0, "data":
+      ""}, "desconto2": {"codigoDesconto": "NAOTEMDESCONTO", "taxa": 0, "valor": 0,
+      "data": ""}, "desconto3": {"codigoDesconto": "NAOTEMDESCONTO", "taxa": 0, "valor":
+      0, "data": ""}, "valorNominal": 3, "valorAbatimento": 0, "multa": {"codigoMulta":
+      "NAOTEMMULTA", "valor": 0, "taxa": 0}, "mora": {"codigoMora": "ISENTO", "valor":
+      0, "taxa": 0}, "cnpjCPFBeneficiario": "23130935000198", "numDiasAgenda": "60",
+      "mensagem": {"linha1": "TESTE 1", "linha2": "TESTE 2", "linha3": "TESTE 3",
+      "linha4": "TESTE 4"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer 7769de56-cfe2-4ae0-8a1f-c0933b587d3c
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '984'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.1
+      x-inter-conta-corrente:
+      - '14054310'
+    method: POST
+    uri: https://cdpj.partners.bancointer.com.br/cobranca/v2/boletos
+  response:
+    body:
+      string: '{"seuNumero":"4560","nossoNumero":"01034585562","codigoBarras":"07791940200000003000001112015373201034585562","linhaDigitavel":"07790001161201537320710345855620194020000000300"}'
+    headers:
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 5 Jul 2023 16:19:31 GMT
+      Server:
+      - istio-envoy
+      X-Envoy-Upstream-Service-Time:
+      - '551'
+      X-Rate-Limit-Remaining:
+      - '119'
+      X-Rate-Limit-Time:
+      - '1688574030704'
+      X-Request-Id:
+      - 5ced4d26-d3d1-42f7-ac9c-5fa22c3def1e
+      X-Upstream-Time:
+      - '556'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Migração dos serviços de boleto da V1 para V2.

- Adição de uma função para gerar o token de acesso por meio de credenciais relacionadas ao certificado;
- Adição de uma verificação do tempo que a ultima token foi gerada, como forma reaproveitar a token e evitar a quebra do limite de 5 chamadas por minuto;
- Correção na formatação do corpo das requisições, agora são feitas com aspas duplas como exige a especificação do formato JSON;
- Adição de um mock para os testes, como forma de preservar dados sensíveis, como credenciais e certificado;
- Atualização de chaves e valores para o corpo da requisição, que mudaram da V1 para V2.