### PR TITLE
[FIX] set correct name file directory for bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -15,6 +15,6 @@ replace = v{new_version}.
 search = version = release = '{current_version}'
 replace = version = release = '{new_version}'
 
-[bumpversion:file:src/erpbrasil.bank.inter/__init__.py]
+[bumpversion:file:src/erpbrasil/__init__.py]
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'


### PR DESCRIPTION
Ao tentar rodar o comando do bumpversion para o fechamento da tag, ele está tentando puxar o arquivo de uma pasta que não existe. Seguindo o padrão dos demais repositórios, alterei o nome no arquivo para puxar do local correto.

@mileo 