### PR TITLE
[FIX] set correct version for the bumbpersion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.1.0
 commit = True
 tag = True
 


### PR DESCRIPTION
Coloca a mesma versão do bumpversion que está em: https://github.com/erpbrasil/erpbrasil.bank.inter/blob/master/src/erpbrasil/bank/inter/__init__.py#L1
